### PR TITLE
Fixed: Drag and Drop behavior (Copy or Move) should be modified when holding Ctrl or Shift.

### DIFF
--- a/WastedgeQuerier/Support/DirectoryBrowser.cs
+++ b/WastedgeQuerier/Support/DirectoryBrowser.cs
@@ -219,7 +219,7 @@ namespace WastedgeQuerier.Support
             if (node == null)
                 return;
 
-            var matches = BuildMatches((string)node.Tag, e.DropData);
+            var matches = BuildMatches((string)node.Tag, e);
             if (matches == null)
                 return;
 
@@ -230,9 +230,7 @@ namespace WastedgeQuerier.Support
                 DragDropEffects effect;
 
                 if (match.Kind.IsMove())
-                    effect = (e.KeyState & 8) != 0 ? DragDropEffects.Copy : DragDropEffects.Move;
-                else if (match.Kind.IsCopy())
-                    effect = (e.KeyState & 4) != 0 ? DragDropEffects.Move : DragDropEffects.Copy;
+                    effect = DragDropEffects.Move;
                 else
                     effect = DragDropEffects.Copy;
 
@@ -248,9 +246,9 @@ namespace WastedgeQuerier.Support
             e.Effect = effectiveEffect & e.AllowedEffect;
         }
 
-        private List<DropMatch> BuildMatches(string targetPath, FilesDropData dropData)
+        private List<DropMatch> BuildMatches(string targetPath, FilesDragEventArgs e)
         {
-            return DropMatch.FromDropData(Root, targetPath, FileBrowserManager, dropData);
+            return DropMatch.FromDropData(Root, targetPath, FileBrowserManager, e);
         }
 
         private void _dragDropManager_DragDrop(object sender, FilesDragEventArgs e)
@@ -263,7 +261,7 @@ namespace WastedgeQuerier.Support
 
             string targetPath = (string)node.Tag;
 
-            var matches = BuildMatches(targetPath, e.DropData);
+            var matches = BuildMatches(targetPath, e);
             if (matches == null)
                 return;
 

--- a/WastedgeQuerier/Support/FileBrowser.cs
+++ b/WastedgeQuerier/Support/FileBrowser.cs
@@ -125,7 +125,7 @@ namespace WastedgeQuerier.Support
             if (Directory == null)
                 return;
 
-            var matches = BuildMatches(e.DropData);
+            var matches = BuildMatches(e);
             if (matches == null)
                 return;
 
@@ -138,9 +138,7 @@ namespace WastedgeQuerier.Support
                 if (match.Kind.IsDirectory())
                     effect = DragDropEffects.None;
                 else if (match.Kind.IsMove())
-                    effect = (e.KeyState & 8) != 0 ? DragDropEffects.Copy : DragDropEffects.Move;
-                else if (match.Kind.IsCopy())
-                    effect = (e.KeyState & 4) != 0 ? DragDropEffects.Move : DragDropEffects.Copy;
+                    effect = DragDropEffects.Move;
                 else
                     effect = DragDropEffects.Copy;
 
@@ -156,14 +154,14 @@ namespace WastedgeQuerier.Support
             e.Effect = effectiveEffect & e.AllowedEffect;
         }
 
-        private List<DropMatch> BuildMatches(FilesDropData dropData)
+        private List<DropMatch> BuildMatches(FilesDragEventArgs e)
         {
-            return DropMatch.FromDropData(Directory, Directory, FileBrowserManager, dropData);
+            return DropMatch.FromDropData(Directory, Directory, FileBrowserManager, e);
         }
 
         private void _dragDropManager_DragDrop(object sender, FilesDragEventArgs e)
         {
-            var matches = BuildMatches(e.DropData);
+            var matches = BuildMatches(e);
             if (matches == null)
                 return;
 


### PR DESCRIPTION
The issue was: if you hold the Ctrl key and drag a file from File Browser to Directory, the cursor correctly changes to "Copy", but the behavior is still Move.

I mainly changed DropMatch.FromDropData function so that it takes KeyState into account.