### PR TITLE
Fixed: (WS-136) "Access to disposed object" error when closing ResulForm before result returns.

### DIFF
--- a/WastedgeQuerier/EditInExcel/ResultForm.cs
+++ b/WastedgeQuerier/EditInExcel/ResultForm.cs
@@ -84,6 +84,9 @@ namespace WastedgeQuerier.EditInExcel
 
         private void LoadResultSet(ResultSet resultSet)
         {
+            if (IsDisposed)
+                return;
+
             if (_grid.RowsCount == 0)
                 CreateHeaders(resultSet);
 


### PR DESCRIPTION


Bug: WS-136